### PR TITLE
User ConfigParser instead of RawConfigParser

### DIFF
--- a/taxi/settings.py
+++ b/taxi/settings.py
@@ -101,7 +101,7 @@ class Settings(object):
     }
 
     def __init__(self, file):
-        self.config = configparser.RawConfigParser(allow_no_value=True)
+        self.config = configparser.ConfigParser(allow_no_value=True)
         self.filepath = os.path.expanduser(file)
         self._settings = {}
 


### PR DESCRIPTION
It would be nice to be able to use [interpolation of values](https://docs.python.org/3/library/configparser.html#interpolation-of-values) in the config file.
It would allow to store variables with role id's and use those variables in custom aliases.