### PR TITLE
Update default config paths in documentation

### DIFF
--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -34,8 +34,8 @@ Since this is the first time you run Taxi, you'll get asked a few questions::
     ================
 
     It looks like this is the first time you run Taxi. You will need a
-    configuration file (~/.taxirc) to proceed. Please answer a few questions to
-    create your configuration file.
+    configuration file (~/.config/taxi/taxirc) in order to proceed.
+    Please answer a few questions to create your configuration file.
 
     Backend you want to use (choices are dummy, zebra): zebra
     Username or token: b4b8123f4addb27ad0eb0b2b0a0ae81730af96b8
@@ -366,9 +366,9 @@ Configuration
 
 The configuration file uses the `XDG user directories <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_ specification. This means the location is the following:
 
-    * Linux: ``~/.local/share/taxi/.taxirc``
-    * OS X: ``~/Library/Application Support/taxi/.taxirc``
-    * Windows: ``C:\Documents and Settings\<User>\Application Data\Local Settings\sephii\taxi\.taxirc``
+    * Linux: ``~/.config/taxi/taxirc``
+    * OS X: ``~/Library/Application Support/taxi/taxirc``
+    * Windows: ``%LOCALAPPDATA%\sephii\taxi\taxirc`` or ``C:\Users\<User>\AppData\Local\sephii\taxi\taxirc``
 
 The configuration file has a section named ``backends`` that allows you to
 define the active backends and the credentials you want to use. The syntax of


### PR DESCRIPTION
* Current config file does not start with a dot
* Replace path of Windows XP era
* Add Windows path with variable to stay consistent with Linux and macOS (does this make sense ?)

Note that the user config path has changed for macOS 1.5 years ago, but there have been no release since then : https://github.com/ActiveState/appdirs/commit/c99f3303007a1803cbaa23fc2830336ec551460b#diff-568ec20239bf0f59cbc260962aaf3db4R198

