### PR TITLE
Allow activity.id + project.id to be strings, allow aliases to be written in uppercase in timesheet entries

### DIFF
--- a/taxi/commands/alias.py
+++ b/taxi/commands/alias.py
@@ -62,6 +62,8 @@ def add(ctx, alias, mapping, backend):
 
 
 def add_mapping(ctx, alias, mapping, backend):
+    alias = alias.lower()
+
     if mapping:
         mapping = Project.str_to_tuple(mapping)
         if mapping is None:

--- a/taxi/commands/project.py
+++ b/taxi/commands/project.py
@@ -96,7 +96,7 @@ def alias(ctx, search, backend):
 @project.command(name='show', short_help="Show the details of the given "
                                          "project id.")
 @click.option('--backend', '-b', help="Show project of given backend.")
-@click.argument('project_id', type=int)
+@click.argument('project_id')
 @click.pass_context
 def show(ctx, project_id, backend):
     """

--- a/taxi/commands/show.py
+++ b/taxi/commands/show.py
@@ -32,6 +32,8 @@ def show(ctx, search):
 
 
 def get_alias_matches(search, matches):
+    search = search.lower()
+
     if search in aliases_database:
         matches['aliases'].append(aliases_database[search])
 
@@ -41,6 +43,8 @@ def get_alias_matches(search, matches):
 def get_mapping_matches(search, matches, projects_db):
     if '/' not in search:
         return matches
+
+    search = search.lower()
 
     try:
         mapping = Project.str_to_tuple(search)
@@ -55,7 +59,7 @@ def get_mapping_matches(search, matches, projects_db):
     project_activity = None
 
     for activity in project.activities:
-        if activity.id == mapping[1]:
+        if str(activity.id) == str(mapping[1]):
             project_activity = activity
 
     if project and project_activity:
@@ -65,12 +69,9 @@ def get_mapping_matches(search, matches, projects_db):
 
 
 def get_project_matches(search, matches, projects_db):
-    try:
-        project_id = int(search)
-    except ValueError:
-        return matches
+    search = search.lower()
 
-    project = projects_db.get(project_id)
+    project = projects_db.get(search)
     if project:
         matches['projects'].append((project, None))
 

--- a/taxi/projects.py
+++ b/taxi/projects.py
@@ -28,7 +28,7 @@ class Project:
     }
 
     def __init__(self, id, name, status=None, description=None, budget=None, team=None):
-        self.id = int(id)
+        self.id = id.lower() if isinstance(id, str) else int(id)
         self.name = name
         self.activities = []
         self.status = int(status) if status is not None else None
@@ -79,7 +79,7 @@ Description: %s""" % (self.id, self.name, status, start_date, end_date,
 
     def get_activity(self, id):
         for activity in self.activities:
-            if activity.id == id:
+            if str(activity.id) == str(id):
                 return activity
 
         return None
@@ -105,7 +105,7 @@ Description: %s""" % (self.id, self.name, status, start_date, end_date,
         not numeric.
         """
         parts = string.split('/', 2)
-        return tuple((int(parts[i]) if i < len(parts) else None) for i in range(3))
+        return tuple((parts[i] if i < len(parts) else None) for i in range(3))
 
     @classmethod
     def tuple_to_str(cls, t):
@@ -117,8 +117,8 @@ Description: %s""" % (self.id, self.name, status, start_date, end_date,
 
 
 class Activity:
-    def __init__(self, id, name, price):
-        self.id = int(id)
+    def __init__(self, id, name, price=None):
+        self.id = id.lower() if isinstance(id, str) else int(id)
         self.name = name
         self.price = price
 
@@ -178,7 +178,7 @@ class ProjectsDb:
             for s in search:
                 s = s.lower()
                 found = (project.name.lower().find(s) > -1 or
-                         str(project.id) == s)
+                         str(project.id).lower().find(s) > -1)
 
                 if not found:
                     break
@@ -198,7 +198,7 @@ class ProjectsDb:
             self._projects_by_id_cache = defaultdict(list)
 
             for project in projects:
-                self._projects_by_id_cache[project.id].append(project)
+                self._projects_by_id_cache[str(project.id).lower()].append(project)
 
         for project in self._projects_by_id_cache.get(id, []):
             if backend is None or project.backend == backend:

--- a/taxi/timesheet/entry.py
+++ b/taxi/timesheet/entry.py
@@ -46,7 +46,7 @@ class Entry(FlaggableMixin):
         super(Entry, self).__init__()
 
         self._text = text
-        self.alias = alias
+        self.alias = alias.lower()
         self.duration = duration
         self.description = description
         self.previous_entry = None


### PR DESCRIPTION
Fix #129

The tests are passing, but I don't know how much they really cover. I've tested locally every command listed when running `taxi` with as many options as possible, but only with my current setup (for an alias `infra-42 = INFRA/42`,  `project.id = "INFRA"` and `activity.id = 42`).

@sephii it would be nice if you could try it out with Zebra's setup to make sure it has not broken anything.